### PR TITLE
Add additional dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+audio.pyc

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ clarifai==2.0.21
 SpeechRecognition==3.6.3
 sphinx==1.5.5
 faker==0.7.10
+scipy==1.0.0
+google-api-python-client==1.6.4


### PR DESCRIPTION
Needs a couple additional dependencies in order to work (scipy and google-api-python-client) that are not automatically installed by pip. Also added a .gitignore file that ignores audio.pyc, which appears to be an auto-created file that shouldn't be tracked.